### PR TITLE
Expose ports for HTTP/1.1 and HTTP/2

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
     users-service:
         ports: 
             - "5000:80"
+            - "5001:5001"
         environment:      
             - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
             - ASPNETCORE_URLS=http://*:80

--- a/src/microservices/users/src/Api/Dockerfile
+++ b/src/microservices/users/src/Api/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS base
 WORKDIR /app
 EXPOSE 80
+EXPOSE 5001
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /src

--- a/src/microservices/users/src/Api/Interceptors/ServerInterceptor.cs
+++ b/src/microservices/users/src/Api/Interceptors/ServerInterceptor.cs
@@ -22,6 +22,8 @@
         {
             using (this.metricsRegistry.HistogramGrpcCallsDuration())
             {
+                this.metricsRegistry.CountGrpcCalls();
+
                 try
                 {
                     TResponse response = await base.UnaryServerHandler(request, context, continuation);

--- a/src/microservices/users/src/Api/Program.cs
+++ b/src/microservices/users/src/Api/Program.cs
@@ -31,7 +31,20 @@ namespace Api
                 .UseSerilog()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseStartup<Startup>();
+                    webBuilder
+                        .UseStartup<Startup>()
+                        .ConfigureKestrel(options =>
+                            {
+                                options.Listen(IPAddress.Any, 80, listenOptions =>
+                                {
+                                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                });
+
+                                options.Listen(IPAddress.Any, 5001, listenOptions =>
+                                {
+                                    listenOptions.Protocols = HttpProtocols.Http2;
+                                });
+                            });
                 });
     }
 }


### PR DESCRIPTION
- Expose different ports for supporting HTTP/1.1 and HTTP/2. The change is required because gRPC requires HTTP/2 for communication protocol, but we are also using HTTP/1.1 for metrics export. Eventually we must expose different ports supporting both versions of HTTP
- Add gRPC calls counter inside server interceptor.