### PR TITLE
Adding build clarifications to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ You can run the services by executing `docker-compose` command:
 docker-compose -f docker.compose.yml -f docker.compose.dev.yml up
 ```
 
+**Note that this will not rebuild the solution if there are any changes. Rebuild with**
+
+```docker
+docker-compose build
+```
+
 ### External dependencies
 
 After running the services, some of them might not function correctly as they are using external tools for logging, monitoring, etc.


### PR DESCRIPTION
The current solution may lead you to believing you have messed something up if you forget to rebuild. Better have it explicitly in the readme and make it part of a future build process with a signle command.