### PR TITLE
Replace Elasticsearch with HTTP sink and log directly to Logstash

### DIFF
--- a/src/microservices/users/src/Api/Api.csproj
+++ b/src/microservices/users/src/Api/Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.26.0"/>
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.3.1"/>
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.0.1"/>
+    <PackageReference Include="Serilog.Sinks.Http" Version="5.2.1" />
     <PackageReference Include="Jaeger" Version="0.3.6"/>
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2"/>
   </ItemGroup>

--- a/src/microservices/users/src/Api/appsettings.json
+++ b/src/microservices/users/src/Api/appsettings.json
@@ -12,12 +12,10 @@
     ],
     "WriteTo": [
       {
-        "Name": "Elasticsearch",
+        "Name": "DurableHttpUsingFileSizeRolledBuffers",
         "Args": {
-          "nodeUris": "http://elasticsearch:9200",
-          "autoRegisterTemplate": true,
-          "restrictedToMinimumLevel": "Debug",
-          "indexFormat": "users-service-index-{0:yyyy.MM.dd}"
+          "requestUri": "http://logstash:9600",
+          "period": "00:00:05"
         }
       },
       {


### PR DESCRIPTION
Install Serilog HTTP sink and write logs inside Logstash, instead of directly to Elasticsearch.