### PR TITLE
 Extend Jaeger configuration and export it in appsettings

### DIFF
--- a/compose/tracing/README.MD
+++ b/compose/tracing/README.MD
@@ -24,7 +24,14 @@ The following command will run dev env of Jaeger
 docker-compose up
 ```
 
-This should service **Jaeger UI on port 16686**.
+You can then navigate to http://localhost:16686 to access the Jaeger UI.
+
+The container exposes the following ports:
+|   Port    |   Protocol   | Component | Function                                              |
+|:---------:|:------------:|:---------:| ----------------------------------------------------- |
+|   6831    |     UDP      |   agent   | accept `jaeger.thrift` over compact thrift protocol   |
+|   5778    |     HTTP     |   agent   | serve configs                                         |
+|   16686   |     HTTP     |   query   | serve frontend                                        |
 
 ### Monitoring
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -10,3 +10,9 @@ services:
         environment:      
             - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
             - ASPNETCORE_URLS=http://*:80
+            - jaeger__enabled=true
+            - jaeger__serviceName=users-service
+            - jaeger__udpHost=jaeger
+            - jaeger__udpPort=6831
+            - jaeger__maxPacketSize=0
+            - jaeger__sampler=const

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,11 +9,6 @@ services:
             dockerfile: src/microservices/users/src/Api/Dockerfile
         networks:
             - portfolio-manager
-        environment:
-            - JAEGER_SERVICE_NAME=users
-            - JAEGER_AGENT_HOST=jaeger
-            - JAEGER_AGENT_PORT=6831
-            - JAEGER_SAMPLER_MANAGER_HOST_PORT=jaeger:5778
 
 networks:
     portfolio-manager:

--- a/src/microservices/users/src/Api/Api.csproj
+++ b/src/microservices/users/src/Api/Api.csproj
@@ -4,26 +4,26 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Protobuf Include="Protos\users.proto" GrpcServices="Both"/>
+    <Protobuf Include="Protos\users.proto" GrpcServices="Both" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0"/>
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3"/>
-    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1"/>
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0"/>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1"/>
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0"/>
-    <PackageReference Include="prometheus-net" Version="3.4.0"/>
-    <PackageReference Include="prometheus-net.AspNetCore" Version="3.4.0"/>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.26.0"/>
-    <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.3.1"/>
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.0.1"/>
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="prometheus-net" Version="3.4.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.26.0" />
+    <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.3.1" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.0.1" />
     <PackageReference Include="Serilog.Sinks.Http" Version="5.2.1" />
-    <PackageReference Include="Jaeger" Version="0.3.6"/>
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2"/>
+    <PackageReference Include="Jaeger" Version="0.3.6" />
+    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Application\Application.csproj"/>
-    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj"/>
+    <ProjectReference Include="..\Application\Application.csproj" />
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/src/microservices/users/src/Api/Config/Jaeger/JaegerExtensions.cs
+++ b/src/microservices/users/src/Api/Config/Jaeger/JaegerExtensions.cs
@@ -1,0 +1,75 @@
+﻿namespace Api.Config.Jaeger
+{
+    using Api.Constants;
+    using global::Jaeger;
+    using global::Jaeger.Reporters;
+    using global::Jaeger.Samplers;
+    using global::Jaeger.Senders;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using OpenTracing;
+    using OpenTracing.Util;
+
+    public static class JaegerExtensions
+    {
+        public static IServiceCollection ConfigureTracingServices(this IServiceCollection services)
+        {
+            JaegerOptions jaegerOptions = GetJaegerOptions(services);
+
+            if (!jaegerOptions.Enabled)
+            {
+                return services;
+            }
+
+            services.AddSingleton<ITracer>(serviceProvider =>
+            {
+                ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+
+                RemoteReporter reporter = new RemoteReporter
+                        .Builder()
+                    .WithSender(new UdpSender(jaegerOptions.UdpHost, jaegerOptions.UdpPort, jaegerOptions.MaxPacketSize))
+                    .WithLoggerFactory(loggerFactory)
+                    .Build();
+
+                ISampler sampler = GetJaegerSampler(jaegerOptions);
+
+                Tracer tracer = new Tracer
+                        .Builder(jaegerOptions.ServiceName)
+                    .WithReporter(reporter)
+                    .WithSampler(sampler)
+                    .Build();
+
+                GlobalTracer.Register(tracer);
+
+                return tracer;
+            });
+
+            services.AddOpenTracing();
+
+            return services;
+        }
+
+        private static JaegerOptions GetJaegerOptions(IServiceCollection services)
+        {
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IConfiguration configuration = serviceProvider.GetService<IConfiguration>();
+            services.Configure<JaegerOptions>(configuration.GetSection(ApplicationSettingKeys.JaegerKey));
+
+            return services.BuildServiceProvider().GetRequiredService<IOptions<JaegerOptions>>().Value;
+        }
+
+        private static ISampler GetJaegerSampler(JaegerOptions options)
+        {
+            return options.Sampler switch
+            {
+                "const" => new ConstSampler(true),
+                "rate" => new RateLimitingSampler(options.MaxTracesPerSecond),
+                "probabilistic" => new ProbabilisticSampler(options.SamplingRate),
+                _ => new ConstSampler(true),
+            };
+        }
+
+    }
+}

--- a/src/microservices/users/src/Api/Config/Jaeger/JaegerOptions.cs
+++ b/src/microservices/users/src/Api/Config/Jaeger/JaegerOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace Api.Config.Jaeger
+{
+    public class JaegerOptions
+    {
+        public bool Enabled { get; set; }
+
+        public string ServiceName { get; set; }
+
+        public string UdpHost { get; set; }
+
+        public int UdpPort { get; set; }
+
+        public int MaxPacketSize { get; set; }
+
+        public string Sampler { get; set; }
+
+        public double MaxTracesPerSecond { get; set; } = 5;
+
+        public double SamplingRate { get; set; } = 0.2;
+    }
+}

--- a/src/microservices/users/src/Api/Constants/ApplicationSettingKeys.cs
+++ b/src/microservices/users/src/Api/Constants/ApplicationSettingKeys.cs
@@ -1,0 +1,7 @@
+﻿namespace Api.Constants
+{
+    public class ApplicationSettingKeys
+    {
+        public const string JaegerKey = "jaeger";
+    }
+}

--- a/src/microservices/users/src/Api/Startup.cs
+++ b/src/microservices/users/src/Api/Startup.cs
@@ -2,12 +2,7 @@ namespace Api
 {
     using System;
     using System.Threading.Tasks;
-    using System.Reflection;
-    using Api.Interceptors;
-    using Jaeger;
-    using Jaeger.Samplers;
     using Application.Interfaces.Infrastructure.Metrics;
-    using Infrastructure.Metrics;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
@@ -15,12 +10,11 @@ namespace Api
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
-    using OpenTracing;
-    using OpenTracing.Util;
     using Prometheus;
-    using Prometheus.DotNetRuntime;
     using Serilog;
-    using Jaeger.Reporters;
+    using Api.Config.Jaeger;
+    using Infrastructure.Metrics;
+    using Api.Interceptors;
 
     public class Startup
     {
@@ -41,28 +35,13 @@ namespace Api
         {
             this.ConfigureLoggingServices(services);
             this.ConfigureGrpcServices(services);
-            this.ConfigureTracingServices(services);
+            services.ConfigureTracingServices();
         }
 
         // This method configures the logging fo the application using Serilog
         public void ConfigureLoggingServices(IServiceCollection services)
         {
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
-        }
-
-        public void ConfigureTracingServices(IServiceCollection services)
-        {
-            services.AddSingleton<ITracer>(serviceProvider =>
-            {
-                ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-                var config = Jaeger.Configuration.FromEnv(loggerFactory);
-                ITracer tracer = config.GetTracer();
-                GlobalTracer.Register(tracer);
-
-                return tracer;
-            });
-
-            services.AddOpenTracing();
         }
 
         public void ConfigureGrpcServices(IServiceCollection services)

--- a/src/microservices/users/src/Api/appsettings.json
+++ b/src/microservices/users/src/Api/appsettings.json
@@ -29,6 +29,14 @@
       "Application": "users-service"
     }
   },
+  "jaeger": {
+    "enabled": false,
+    "serviceName": "users-service",
+    "udpHost": "localhost",
+    "udpPort": 6831,
+    "maxPacketSize": 0,
+    "sampler": "const"
+  },
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http1AndHttp2"


### PR DESCRIPTION
- Describe all exposed ports in tracing `README.MD` file
- Move environment variables to `docker-compose.dev.yaml` as they are required only for local development/testing
- Expose Jaeger configuration in `appsettings`
- Add Jaeger configuration in `docker-compose.dev.yaml`